### PR TITLE
Improve readme wording

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,9 @@ If you already have TinyMCE Advanced installed, you will need to deactivate and 
 Compatible with ClassicPress 1.x.x. It should also continue to work on WordPress 4.9.x installations without any problem. PHP 7.3 ready.
 
 # Contributing
-If you find an error, please submit an issue. If you can fix it, please submit a pull request. Note that this plugin is not planned for further development. Critical bugs and security issues will be addressed, if they arise, but the plugin isn't planned for feature development.
+If you find an error, please submit an issue. If you can fix it, please submit a pull request.
+
+Contributions are accepted, and critical bugs and security issues will be addressed if they arise.  However, please note that this plugin is generally considered **feature complete** and significant further development is not planned at this time.
 
 # Screenshot
 ![Screenshot](screenshot.png)


### PR DESCRIPTION
"this plugin is not planned for further development" and then "the plugin isn't planned for feature development" in the next sentence... I took a shot at improving this wording.

I also tried to leave things more open to future contributions. I am guessing at your intent here, so I'm happy to update if that's not quite right.